### PR TITLE
[main] Update gradle to 8.8

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://artifactory.ida.avast.com/artifactory/re-generic-local/gradle/gradle-8.7-bin.zip
+distributionUrl=https\://artifactory.ida.avast.com/artifactory/re-generic-local/gradle/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `main`:
 - Update gradle to 8.8 (7396928e)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)